### PR TITLE
fix(ios): hmac typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,36 +72,36 @@ if (!Capacitor.isNativePlatform()) {
 
 <docgen-index>
 
-- [`load(...)`](#load)
-- [`registerIdentifiedUser(...)`](#registeridentifieduser)
-- [`loginIdentifiedUser(...)`](#loginidentifieduser)
-- [`registerUnidentifiedUser()`](#registerunidentifieduser)
-- [`loginUnidentifiedUser()`](#loginunidentifieduser)
-- [`updateUser(...)`](#updateuser)
-- [`logout()`](#logout)
-- [`logEvent(...)`](#logevent)
-- [`displayMessenger()`](#displaymessenger)
-- [`displayMessageComposer(...)`](#displaymessagecomposer)
-- [`displayHelpCenter()`](#displayhelpcenter)
-- [`hideMessenger()`](#hidemessenger)
-- [`displayLauncher()`](#displaylauncher)
-- [`hideLauncher()`](#hidelauncher)
-- [`displayInAppMessages()`](#displayinappmessages)
-- [`hideInAppMessages()`](#hideinappmessages)
-- [`displayCarousel(...)`](#displaycarousel)
-- [`setUserHash(...)`](#setuserhash)
-- [`setBottomPadding(...)`](#setbottompadding)
-- [`sendPushTokenToIntercom(...)`](#sendpushtokentointercom)
-- [`receivePush(...)`](#receivepush)
-- [`displayArticle(...)`](#displayarticle)
-- [`presentContent(...)`](#presentcontent)
-- [`present(...)`](#present)
-- [`setupUnreadConversationListener()`](#setupunreadconversationlistener)
-- [`removeUnreadConversationListener()`](#removeunreadconversationlistener)
-- [`getUnreadConversationCount()`](#getunreadconversationcount)
-- [`addListener(...)`](#addlistener)
-- [Interfaces](#interfaces)
-- [Enums](#enums)
+* [`load(...)`](#load)
+* [`registerIdentifiedUser(...)`](#registeridentifieduser)
+* [`loginIdentifiedUser(...)`](#loginidentifieduser)
+* [`registerUnidentifiedUser()`](#registerunidentifieduser)
+* [`loginUnidentifiedUser()`](#loginunidentifieduser)
+* [`updateUser(...)`](#updateuser)
+* [`logout()`](#logout)
+* [`logEvent(...)`](#logevent)
+* [`displayMessenger()`](#displaymessenger)
+* [`displayMessageComposer(...)`](#displaymessagecomposer)
+* [`displayHelpCenter()`](#displayhelpcenter)
+* [`hideMessenger()`](#hidemessenger)
+* [`displayLauncher()`](#displaylauncher)
+* [`hideLauncher()`](#hidelauncher)
+* [`displayInAppMessages()`](#displayinappmessages)
+* [`hideInAppMessages()`](#hideinappmessages)
+* [`displayCarousel(...)`](#displaycarousel)
+* [`setUserHash(...)`](#setuserhash)
+* [`setBottomPadding(...)`](#setbottompadding)
+* [`sendPushTokenToIntercom(...)`](#sendpushtokentointercom)
+* [`receivePush(...)`](#receivepush)
+* [`displayArticle(...)`](#displayarticle)
+* [`presentContent(...)`](#presentcontent)
+* [`present(...)`](#present)
+* [`setupUnreadConversationListener()`](#setupunreadconversationlistener)
+* [`removeUnreadConversationListener()`](#removeunreadconversationlistener)
+* [`getUnreadConversationCount()`](#getunreadconversationcount)
+* [`addListener(...)`](#addlistener)
+* [Interfaces](#interfaces)
+* [Enums](#enums)
 
 </docgen-index>
 
@@ -124,7 +124,8 @@ Only available for Web
 | ------------ | --------------------------------------------------------------- |
 | **`config`** | <code><a href="#intercomwebconfig">IntercomWebConfig</a></code> |
 
----
+--------------------
+
 
 ### registerIdentifiedUser(...)
 
@@ -136,7 +137,8 @@ registerIdentifiedUser(options: { userId?: string; email?: string; }) => Promise
 | ------------- | ------------------------------------------------- |
 | **`options`** | <code>{ userId?: string; email?: string; }</code> |
 
----
+--------------------
+
 
 ### loginIdentifiedUser(...)
 
@@ -150,7 +152,8 @@ Login an identified user with Intercom.
 | ------------- | ------------------------------------------------- |
 | **`options`** | <code>{ userId?: string; email?: string; }</code> |
 
----
+--------------------
+
 
 ### registerUnidentifiedUser()
 
@@ -158,7 +161,8 @@ Login an identified user with Intercom.
 registerUnidentifiedUser() => Promise<void>
 ```
 
----
+--------------------
+
 
 ### loginUnidentifiedUser()
 
@@ -168,7 +172,8 @@ loginUnidentifiedUser() => Promise<void>
 
 Login an unidentified user with Intercom.
 
----
+--------------------
+
 
 ### updateUser(...)
 
@@ -182,7 +187,8 @@ Updates a user's attributes in Intercom.
 | ------------- | ------------------------------------------------------------------------------- |
 | **`options`** | <code><a href="#intercomuserupdateoptions">IntercomUserUpdateOptions</a></code> |
 
----
+--------------------
+
 
 ### logout()
 
@@ -192,7 +198,8 @@ logout() => Promise<void>
 
 Logs the user out of Intercom.
 
----
+--------------------
+
 
 ### logEvent(...)
 
@@ -206,7 +213,8 @@ Logs an event with optional metadata in Intercom.
 | ------------- | ------------------------------------------ |
 | **`options`** | <code>{ name: string; data?: any; }</code> |
 
----
+--------------------
+
 
 ### displayMessenger()
 
@@ -214,7 +222,8 @@ Logs an event with optional metadata in Intercom.
 displayMessenger() => Promise<void>
 ```
 
----
+--------------------
+
 
 ### displayMessageComposer(...)
 
@@ -228,7 +237,8 @@ Displays the Intercom Message Composer with an initial message.
 | ------------- | --------------------------------- |
 | **`options`** | <code>{ message: string; }</code> |
 
----
+--------------------
+
 
 ### displayHelpCenter()
 
@@ -236,7 +246,8 @@ Displays the Intercom Message Composer with an initial message.
 displayHelpCenter() => Promise<void>
 ```
 
----
+--------------------
+
 
 ### hideMessenger()
 
@@ -246,7 +257,8 @@ hideMessenger() => Promise<void>
 
 Hides the Intercom Messenger.
 
----
+--------------------
+
 
 ### displayLauncher()
 
@@ -256,7 +268,8 @@ displayLauncher() => Promise<void>
 
 Displays the default Intercom Launcher.
 
----
+--------------------
+
 
 ### hideLauncher()
 
@@ -266,7 +279,8 @@ hideLauncher() => Promise<void>
 
 Hides the Intercom Launcher.
 
----
+--------------------
+
 
 ### displayInAppMessages()
 
@@ -276,7 +290,8 @@ displayInAppMessages() => Promise<void>
 
 Displays Intercom In-App Messages.
 
----
+--------------------
+
 
 ### hideInAppMessages()
 
@@ -286,7 +301,8 @@ hideInAppMessages() => Promise<void>
 
 Hides Intercom In-App Messages.
 
----
+--------------------
+
 
 ### displayCarousel(...)
 
@@ -298,7 +314,8 @@ displayCarousel(options: { carouselId: string; }) => Promise<void>
 | ------------- | ------------------------------------ |
 | **`options`** | <code>{ carouselId: string; }</code> |
 
----
+--------------------
+
 
 ### setUserHash(...)
 
@@ -312,7 +329,8 @@ Sets the HMAC user hash for Intercom Identity Verification.
 | ------------- | ------------------------------ |
 | **`options`** | <code>{ hmac: string; }</code> |
 
----
+--------------------
+
 
 ### setBottomPadding(...)
 
@@ -326,7 +344,8 @@ Sets the bottom padding for the Intercom Messenger.
 | ------------- | ------------------------------- |
 | **`options`** | <code>{ value: string; }</code> |
 
----
+--------------------
+
 
 ### sendPushTokenToIntercom(...)
 
@@ -340,7 +359,8 @@ Sends a push token to Intercom.
 | ------------- | ------------------------------- |
 | **`options`** | <code>{ value: string; }</code> |
 
----
+--------------------
+
 
 ### receivePush(...)
 
@@ -354,7 +374,8 @@ Processes a received Intercom push notification.
 | ------------------ | ------------------------------------------------------------------------------------- |
 | **`notification`** | <code><a href="#intercompushnotificationdata">IntercomPushNotificationData</a></code> |
 
----
+--------------------
+
 
 ### displayArticle(...)
 
@@ -366,7 +387,8 @@ displayArticle(options: { articleId: string; }) => Promise<void>
 | ------------- | ----------------------------------- |
 | **`options`** | <code>{ articleId: string; }</code> |
 
----
+--------------------
+
 
 ### presentContent(...)
 
@@ -380,7 +402,8 @@ Presents an Intercom content item by its type and ID.
 | ------------- | ------------------------------------------------------------------------------------------------ |
 | **`options`** | <code>{ contentType: <a href="#intercomcontent">IntercomContent</a>; contentId: string; }</code> |
 
----
+--------------------
+
 
 ### present(...)
 
@@ -394,7 +417,8 @@ Presents the Intercom's space.
 | ------------- | ------------------------------------------------------------------- |
 | **`options`** | <code>{ space: <a href="#intercomspace">IntercomSpace</a>; }</code> |
 
----
+--------------------
+
 
 ### setupUnreadConversationListener()
 
@@ -404,7 +428,8 @@ setupUnreadConversationListener() => Promise<void>
 
 Setup listener for unread conversation count updates.
 
----
+--------------------
+
 
 ### removeUnreadConversationListener()
 
@@ -414,7 +439,8 @@ removeUnreadConversationListener() => Promise<void>
 
 Remove listener for unread conversation count updates.
 
----
+--------------------
+
 
 ### getUnreadConversationCount()
 
@@ -426,7 +452,8 @@ Get current unread conversation count.
 
 **Returns:** <code>Promise&lt;{ unreadCount: number; }&gt;</code>
 
----
+--------------------
+
 
 ### addListener(...)
 
@@ -443,9 +470,11 @@ Listen for when the unread conversation count is changed.
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
----
+--------------------
+
 
 ### Interfaces
+
 
 #### IntercomWebConfig
 
@@ -462,9 +491,10 @@ Represent configs that are available on Intercom Web SDK.
 | **`vertical_padding`**         | <code>number</code>                                                         | Configure Intercom default launcher icon's vertical padding. Move the default launcher icon vertically. Padding from bottom of screen. Minimum value: 20. Does not work on mobile. Only available for Web                                                             |
 | **`horizontal_padding`**       | <code>number</code>                                                         | Configure Intercom default launcher icon's horizontal padding. Move the default launcher icon horizontally. Padding from right side of screen Minimum value: 20. Does not work on mobile. Only available for Web                                                      |
 | **`hide_default_launcher`**    | <code>boolean</code>                                                        | Configure Intercom default launcher icon's visibility. Hide the default launcher icon. Setting to false will forcefully show the launcher icon. Only available for Web                                                                                                |
-| **`session_duration`**         | <code>number</code>                                                         | Configure Intercom session duration. Time in milliseconds for the Intercom session to be considered active. A value of 5 _ 60 _ 1000 would set the expiry time to be 5 minutes Only available for Web                                                                 |
+| **`session_duration`**         | <code>number</code>                                                         | Configure Intercom session duration. Time in milliseconds for the Intercom session to be considered active. A value of 5 * 60 * 1000 would set the expiry time to be 5 minutes Only available for Web                                                                 |
 | **`action_color`**             | <code>string</code>                                                         | Configure action color for Intercom. Used in button links and more to highlight and emphasise. The color string can be any valid CSS Color Name HEX or RGB Only available for Web                                                                                     |
 | **`background_color`**         | <code>string</code>                                                         | Configure background color for Intercom. Used behind your team profile and other attributes. The color string can be any valid CSS Color Name HEX or RGB Only available for Web                                                                                       |
+
 
 #### IntercomUserUpdateOptions
 
@@ -485,6 +515,7 @@ Only available for iOS and Android.
 | **`company`**          | <code><a href="#companyoption">CompanyOption</a></code> |
 | **`companies`**        | <code>CompanyOption[]</code>                            |
 
+
 #### CompanyOption
 
 <a href="#companyoption">CompanyOption</a> Interface.
@@ -499,6 +530,7 @@ Represents Intercom option to include company details.
 | **`monthlySpend`**     | <code>number</code>                    |                               |
 | **`plan`**             | <code>string</code>                    |                               |
 | **`customAttributes`** | <code>Record&lt;string, any&gt;</code> |                               |
+
 
 #### IntercomPushNotificationData
 
@@ -525,13 +557,16 @@ Only available for iOS and Android.
 | **`title`**                     | <code>string</code> |
 | **`priority`**                  | <code>number</code> |
 
+
 #### PluginListenerHandle
 
 | Prop         | Type                                      |
 | ------------ | ----------------------------------------- |
 | **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
 
+
 ### Enums
+
 
 #### IntercomRegionalApiBase
 
@@ -541,12 +576,14 @@ Only available for iOS and Android.
 | **`Eu`** | <code>'https://api-iam.eu.intercom.io'</code> |
 | **`Au`** | <code>'https://api-iam.au.intercom.io'</code> |
 
+
 #### IntercomAlignment
 
 | Members     | Value                |
 | ----------- | -------------------- |
 | **`Left`**  | <code>'left'</code>  |
 | **`Right`** | <code>'right'</code> |
+
 
 #### IntercomContent
 
@@ -558,6 +595,7 @@ Only available for iOS and Android.
 | **`Checklist`** | <code>'checklist'</code> | Only available for Web             |
 | **`News`**      | <code>'news'</code>      | Only available for Web             |
 | **`Tour`**      | <code>'tour'</code>      | Only available for Web             |
+
 
 #### IntercomSpace
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <h2 align="center">Capacitor Intercom plugin</h2>
-<p align="center"><strong><code>@foodello/intercom</code></strong></p>
+<p align="center"><strong><code>@hildorjr/capacitor-intercom</code></strong></p>
 <p align="center">
   Capacitor plugin for enabling Intercom capabilities based on the Capacitor community plugin
 </p>
 
 <p align="center">
   <img src="https://img.shields.io/maintenance/yes/2023?style=flat-square" />
-  <a href="https://www.npmjs.com/package/@foodello/intercom"><img src="https://img.shields.io/npm/l/@foodello/intercom?style=flat-square" /></a>
+  <a href="https://www.npmjs.com/package/@hildorjr/capacitor-intercom"><img src="https://img.shields.io/npm/l/@hildorjr/capacitor-intercom?style=flat-square" /></a>
 <br>
-  <a href="https://www.npmjs.com/package/@foodello/intercom"><img src="https://img.shields.io/npm/dw/@foodello/intercom?style=flat-square" /></a>
-  <a href="https://www.npmjs.com/package/@foodello/intercom"><img src="https://img.shields.io/npm/v/@foodello/intercom?style=flat-square" /></a>
+  <a href="https://www.npmjs.com/package/@hildorjr/capacitor-intercom"><img src="https://img.shields.io/npm/dw/@hildorjr/capacitor-intercom?style=flat-square" /></a>
+  <a href="https://www.npmjs.com/package/@hildorjr/capacitor-intercom"><img src="https://img.shields.io/npm/v/@hildorjr/capacitor-intercom?style=flat-square" /></a>
   <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 <a href="#contributors"><img src="https://img.shields.io/badge/all%20contributors-14-orange?style=flat-square" /></a>
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
@@ -17,8 +17,7 @@
 
 ## Notice 🚀
 
-Thanks for the all the authors with their work in [`@capacitor-community/intercom`](https://github.com/capacitor-community/intercom
-). We have noticed that the repository was left behind the newest updates and the original repository did not get updates quick enough once pull request were opened. So we decided to serve the newest Intercom capabilities under seperate org until the original repository catches the changes.
+Thanks for the all the authors with their work in [`@capacitor-community/intercom`](https://github.com/capacitor-community/intercom) and in [`@foodello/intercom`](https://github.com/foodello/intercom). We have noticed that the repository was left behind the newest updates and the original repository did not get updates quick enough once pull request were opened. So we decided to serve the newest Intercom capabilities under seperate org until the original repository catches the changes.
 
 **This plugin is built for the Capacitor v4 upwards.**
 
@@ -27,13 +26,13 @@ Thanks for the all the authors with their work in [`@capacitor-community/interco
 Using npm:
 
 ```bash
-npm install @foodello/intercom
+npm install @hildorjr/capacitor-intercom
 ```
 
 Using yarn:
 
 ```bash
-yarn add @foodello/intercom
+yarn add @hildorjr/capacitor-intercom
 ```
 
 Sync native files:
@@ -48,16 +47,17 @@ Import Intercom plugin into your project.
 
 ```js
 import { Capacitor } from '@capacitor/core';
-import { Intercom } from '@foodello/intercom';
+import { Intercom } from '@hildorjr/capacitor-intercom';
 import { PushNotifications } from '@capacitor/push-notifications';
 ```
 
 Initialize Intercom plugin.
+
 ```js
 /**
  * Web requires loading and initializing the script of the SDK
  * with the Intercom web config defined in IntercomWebConfig Interface.
- * 
+ *
  * Only available in Web.
  * @since 4.2.0
  */
@@ -72,36 +72,36 @@ if (!Capacitor.isNativePlatform()) {
 
 <docgen-index>
 
-* [`load(...)`](#load)
-* [`registerIdentifiedUser(...)`](#registeridentifieduser)
-* [`loginIdentifiedUser(...)`](#loginidentifieduser)
-* [`registerUnidentifiedUser()`](#registerunidentifieduser)
-* [`loginUnidentifiedUser()`](#loginunidentifieduser)
-* [`updateUser(...)`](#updateuser)
-* [`logout()`](#logout)
-* [`logEvent(...)`](#logevent)
-* [`displayMessenger()`](#displaymessenger)
-* [`displayMessageComposer(...)`](#displaymessagecomposer)
-* [`displayHelpCenter()`](#displayhelpcenter)
-* [`hideMessenger()`](#hidemessenger)
-* [`displayLauncher()`](#displaylauncher)
-* [`hideLauncher()`](#hidelauncher)
-* [`displayInAppMessages()`](#displayinappmessages)
-* [`hideInAppMessages()`](#hideinappmessages)
-* [`displayCarousel(...)`](#displaycarousel)
-* [`setUserHash(...)`](#setuserhash)
-* [`setBottomPadding(...)`](#setbottompadding)
-* [`sendPushTokenToIntercom(...)`](#sendpushtokentointercom)
-* [`receivePush(...)`](#receivepush)
-* [`displayArticle(...)`](#displayarticle)
-* [`presentContent(...)`](#presentcontent)
-* [`present(...)`](#present)
-* [`setupUnreadConversationListener()`](#setupunreadconversationlistener)
-* [`removeUnreadConversationListener()`](#removeunreadconversationlistener)
-* [`getUnreadConversationCount()`](#getunreadconversationcount)
-* [`addListener(...)`](#addlistener)
-* [Interfaces](#interfaces)
-* [Enums](#enums)
+- [`load(...)`](#load)
+- [`registerIdentifiedUser(...)`](#registeridentifieduser)
+- [`loginIdentifiedUser(...)`](#loginidentifieduser)
+- [`registerUnidentifiedUser()`](#registerunidentifieduser)
+- [`loginUnidentifiedUser()`](#loginunidentifieduser)
+- [`updateUser(...)`](#updateuser)
+- [`logout()`](#logout)
+- [`logEvent(...)`](#logevent)
+- [`displayMessenger()`](#displaymessenger)
+- [`displayMessageComposer(...)`](#displaymessagecomposer)
+- [`displayHelpCenter()`](#displayhelpcenter)
+- [`hideMessenger()`](#hidemessenger)
+- [`displayLauncher()`](#displaylauncher)
+- [`hideLauncher()`](#hidelauncher)
+- [`displayInAppMessages()`](#displayinappmessages)
+- [`hideInAppMessages()`](#hideinappmessages)
+- [`displayCarousel(...)`](#displaycarousel)
+- [`setUserHash(...)`](#setuserhash)
+- [`setBottomPadding(...)`](#setbottompadding)
+- [`sendPushTokenToIntercom(...)`](#sendpushtokentointercom)
+- [`receivePush(...)`](#receivepush)
+- [`displayArticle(...)`](#displayarticle)
+- [`presentContent(...)`](#presentcontent)
+- [`present(...)`](#present)
+- [`setupUnreadConversationListener()`](#setupunreadconversationlistener)
+- [`removeUnreadConversationListener()`](#removeunreadconversationlistener)
+- [`getUnreadConversationCount()`](#getunreadconversationcount)
+- [`addListener(...)`](#addlistener)
+- [Interfaces](#interfaces)
+- [Enums](#enums)
 
 </docgen-index>
 
@@ -124,8 +124,7 @@ Only available for Web
 | ------------ | --------------------------------------------------------------- |
 | **`config`** | <code><a href="#intercomwebconfig">IntercomWebConfig</a></code> |
 
---------------------
-
+---
 
 ### registerIdentifiedUser(...)
 
@@ -137,8 +136,7 @@ registerIdentifiedUser(options: { userId?: string; email?: string; }) => Promise
 | ------------- | ------------------------------------------------- |
 | **`options`** | <code>{ userId?: string; email?: string; }</code> |
 
---------------------
-
+---
 
 ### loginIdentifiedUser(...)
 
@@ -152,8 +150,7 @@ Login an identified user with Intercom.
 | ------------- | ------------------------------------------------- |
 | **`options`** | <code>{ userId?: string; email?: string; }</code> |
 
---------------------
-
+---
 
 ### registerUnidentifiedUser()
 
@@ -161,8 +158,7 @@ Login an identified user with Intercom.
 registerUnidentifiedUser() => Promise<void>
 ```
 
---------------------
-
+---
 
 ### loginUnidentifiedUser()
 
@@ -172,8 +168,7 @@ loginUnidentifiedUser() => Promise<void>
 
 Login an unidentified user with Intercom.
 
---------------------
-
+---
 
 ### updateUser(...)
 
@@ -187,8 +182,7 @@ Updates a user's attributes in Intercom.
 | ------------- | ------------------------------------------------------------------------------- |
 | **`options`** | <code><a href="#intercomuserupdateoptions">IntercomUserUpdateOptions</a></code> |
 
---------------------
-
+---
 
 ### logout()
 
@@ -198,8 +192,7 @@ logout() => Promise<void>
 
 Logs the user out of Intercom.
 
---------------------
-
+---
 
 ### logEvent(...)
 
@@ -213,8 +206,7 @@ Logs an event with optional metadata in Intercom.
 | ------------- | ------------------------------------------ |
 | **`options`** | <code>{ name: string; data?: any; }</code> |
 
---------------------
-
+---
 
 ### displayMessenger()
 
@@ -222,8 +214,7 @@ Logs an event with optional metadata in Intercom.
 displayMessenger() => Promise<void>
 ```
 
---------------------
-
+---
 
 ### displayMessageComposer(...)
 
@@ -237,8 +228,7 @@ Displays the Intercom Message Composer with an initial message.
 | ------------- | --------------------------------- |
 | **`options`** | <code>{ message: string; }</code> |
 
---------------------
-
+---
 
 ### displayHelpCenter()
 
@@ -246,8 +236,7 @@ Displays the Intercom Message Composer with an initial message.
 displayHelpCenter() => Promise<void>
 ```
 
---------------------
-
+---
 
 ### hideMessenger()
 
@@ -257,8 +246,7 @@ hideMessenger() => Promise<void>
 
 Hides the Intercom Messenger.
 
---------------------
-
+---
 
 ### displayLauncher()
 
@@ -268,8 +256,7 @@ displayLauncher() => Promise<void>
 
 Displays the default Intercom Launcher.
 
---------------------
-
+---
 
 ### hideLauncher()
 
@@ -279,8 +266,7 @@ hideLauncher() => Promise<void>
 
 Hides the Intercom Launcher.
 
---------------------
-
+---
 
 ### displayInAppMessages()
 
@@ -290,8 +276,7 @@ displayInAppMessages() => Promise<void>
 
 Displays Intercom In-App Messages.
 
---------------------
-
+---
 
 ### hideInAppMessages()
 
@@ -301,8 +286,7 @@ hideInAppMessages() => Promise<void>
 
 Hides Intercom In-App Messages.
 
---------------------
-
+---
 
 ### displayCarousel(...)
 
@@ -314,8 +298,7 @@ displayCarousel(options: { carouselId: string; }) => Promise<void>
 | ------------- | ------------------------------------ |
 | **`options`** | <code>{ carouselId: string; }</code> |
 
---------------------
-
+---
 
 ### setUserHash(...)
 
@@ -329,8 +312,7 @@ Sets the HMAC user hash for Intercom Identity Verification.
 | ------------- | ------------------------------ |
 | **`options`** | <code>{ hmac: string; }</code> |
 
---------------------
-
+---
 
 ### setBottomPadding(...)
 
@@ -344,8 +326,7 @@ Sets the bottom padding for the Intercom Messenger.
 | ------------- | ------------------------------- |
 | **`options`** | <code>{ value: string; }</code> |
 
---------------------
-
+---
 
 ### sendPushTokenToIntercom(...)
 
@@ -359,8 +340,7 @@ Sends a push token to Intercom.
 | ------------- | ------------------------------- |
 | **`options`** | <code>{ value: string; }</code> |
 
---------------------
-
+---
 
 ### receivePush(...)
 
@@ -374,8 +354,7 @@ Processes a received Intercom push notification.
 | ------------------ | ------------------------------------------------------------------------------------- |
 | **`notification`** | <code><a href="#intercompushnotificationdata">IntercomPushNotificationData</a></code> |
 
---------------------
-
+---
 
 ### displayArticle(...)
 
@@ -387,8 +366,7 @@ displayArticle(options: { articleId: string; }) => Promise<void>
 | ------------- | ----------------------------------- |
 | **`options`** | <code>{ articleId: string; }</code> |
 
---------------------
-
+---
 
 ### presentContent(...)
 
@@ -402,8 +380,7 @@ Presents an Intercom content item by its type and ID.
 | ------------- | ------------------------------------------------------------------------------------------------ |
 | **`options`** | <code>{ contentType: <a href="#intercomcontent">IntercomContent</a>; contentId: string; }</code> |
 
---------------------
-
+---
 
 ### present(...)
 
@@ -417,8 +394,7 @@ Presents the Intercom's space.
 | ------------- | ------------------------------------------------------------------- |
 | **`options`** | <code>{ space: <a href="#intercomspace">IntercomSpace</a>; }</code> |
 
---------------------
-
+---
 
 ### setupUnreadConversationListener()
 
@@ -428,8 +404,7 @@ setupUnreadConversationListener() => Promise<void>
 
 Setup listener for unread conversation count updates.
 
---------------------
-
+---
 
 ### removeUnreadConversationListener()
 
@@ -439,8 +414,7 @@ removeUnreadConversationListener() => Promise<void>
 
 Remove listener for unread conversation count updates.
 
---------------------
-
+---
 
 ### getUnreadConversationCount()
 
@@ -452,8 +426,7 @@ Get current unread conversation count.
 
 **Returns:** <code>Promise&lt;{ unreadCount: number; }&gt;</code>
 
---------------------
-
+---
 
 ### addListener(...)
 
@@ -470,11 +443,9 @@ Listen for when the unread conversation count is changed.
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
---------------------
-
+---
 
 ### Interfaces
-
 
 #### IntercomWebConfig
 
@@ -491,10 +462,9 @@ Represent configs that are available on Intercom Web SDK.
 | **`vertical_padding`**         | <code>number</code>                                                         | Configure Intercom default launcher icon's vertical padding. Move the default launcher icon vertically. Padding from bottom of screen. Minimum value: 20. Does not work on mobile. Only available for Web                                                             |
 | **`horizontal_padding`**       | <code>number</code>                                                         | Configure Intercom default launcher icon's horizontal padding. Move the default launcher icon horizontally. Padding from right side of screen Minimum value: 20. Does not work on mobile. Only available for Web                                                      |
 | **`hide_default_launcher`**    | <code>boolean</code>                                                        | Configure Intercom default launcher icon's visibility. Hide the default launcher icon. Setting to false will forcefully show the launcher icon. Only available for Web                                                                                                |
-| **`session_duration`**         | <code>number</code>                                                         | Configure Intercom session duration. Time in milliseconds for the Intercom session to be considered active. A value of 5 * 60 * 1000 would set the expiry time to be 5 minutes Only available for Web                                                                 |
+| **`session_duration`**         | <code>number</code>                                                         | Configure Intercom session duration. Time in milliseconds for the Intercom session to be considered active. A value of 5 _ 60 _ 1000 would set the expiry time to be 5 minutes Only available for Web                                                                 |
 | **`action_color`**             | <code>string</code>                                                         | Configure action color for Intercom. Used in button links and more to highlight and emphasise. The color string can be any valid CSS Color Name HEX or RGB Only available for Web                                                                                     |
 | **`background_color`**         | <code>string</code>                                                         | Configure background color for Intercom. Used behind your team profile and other attributes. The color string can be any valid CSS Color Name HEX or RGB Only available for Web                                                                                       |
-
 
 #### IntercomUserUpdateOptions
 
@@ -513,7 +483,7 @@ Only available for iOS and Android.
 | **`languageOverride`** | <code>string</code>                                     |
 | **`customAttributes`** | <code>Record&lt;string, any&gt;</code>                  |
 | **`company`**          | <code><a href="#companyoption">CompanyOption</a></code> |
-
+| **`companies`**        | <code>CompanyOption[]</code>                            |
 
 #### CompanyOption
 
@@ -529,7 +499,6 @@ Represents Intercom option to include company details.
 | **`monthlySpend`**     | <code>number</code>                    |                               |
 | **`plan`**             | <code>string</code>                    |                               |
 | **`customAttributes`** | <code>Record&lt;string, any&gt;</code> |                               |
-
 
 #### IntercomPushNotificationData
 
@@ -556,16 +525,13 @@ Only available for iOS and Android.
 | **`title`**                     | <code>string</code> |
 | **`priority`**                  | <code>number</code> |
 
-
 #### PluginListenerHandle
 
 | Prop         | Type                                      |
 | ------------ | ----------------------------------------- |
 | **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
 
-
 ### Enums
-
 
 #### IntercomRegionalApiBase
 
@@ -575,14 +541,12 @@ Only available for iOS and Android.
 | **`Eu`** | <code>'https://api-iam.eu.intercom.io'</code> |
 | **`Au`** | <code>'https://api-iam.au.intercom.io'</code> |
 
-
 #### IntercomAlignment
 
 | Members     | Value                |
 | ----------- | -------------------- |
 | **`Left`**  | <code>'left'</code>  |
 | **`Right`** | <code>'right'</code> |
-
 
 #### IntercomContent
 
@@ -594,7 +558,6 @@ Only available for iOS and Android.
 | **`Checklist`** | <code>'checklist'</code> | Only available for Web             |
 | **`News`**      | <code>'news'</code>      | Only available for Web             |
 | **`Tour`**      | <code>'tour'</code>      | Only available for Web             |
-
 
 #### IntercomSpace
 
@@ -609,6 +572,7 @@ Only available for iOS and Android.
 </docgen-api>
 
 ## Configurations
+
 ### iOS setup
 
 - `ionic start my-cap-app --capacitor`

--- a/ios/Plugin/IntercomPlugin.swift
+++ b/ios/Plugin/IntercomPlugin.swift
@@ -266,7 +266,7 @@ public class IntercomPlugin: CAPPlugin {
     }
     
     @objc func setUserHash(_ call: CAPPluginCall) {
-        guard let hmac = call.getString("hmsc") else {
+        guard let hmac = call.getString("hmac") else {
             call.reject("hmac is missing or empty. Read intercom docs and generate it.")
             return
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@foodello/intercom",
-  "version": "4.3.0",
+  "name": "@hildorjr/capacitor-intercom",
+  "version": "4.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@foodello/intercom",
-      "version": "4.3.0",
+      "name": "@hildorjr/capacitor-intercom",
+      "version": "4.3.1",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/node": "^18.16.0",
         "all-contributors-cli": "^6.20.0",
         "eslint": "^7.11.0",
-        "husky": "^8.0.0",
+        "husky": "^8.0.3",
         "prettier": "~2.3.0",
         "prettier-plugin-java": "~1.0.2",
         "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -82,12 +82,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fiksuruoka-fi/intercom.git"
+    "url": "git+https://github.com/hildorjr/capacitor-intercom.git"
   },
   "bugs": {
-    "url": "https://github.com/fiksuruoka-fi/intercom/issues"
+    "url": "https://github.com/hildorjr/capacitor-intercom/issues"
   },
-  "homepage": "https://github.com/fiksuruoka-fi/intercom#readme",
+  "homepage": "https://github.com/hildorjr/capacitor-intercom#readme",
   "directories": {
     "example": "example"
   }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/node": "^18.16.0",
     "all-contributors-cli": "^6.20.0",
     "eslint": "^7.11.0",
-    "husky": "^8.0.0",
+    "husky": "^8.0.3",
     "prettier": "~2.3.0",
     "prettier-plugin-java": "~1.0.2",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hildorjr/capacitor-intercom",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Enable Intercom features for Capacitor apps",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@foodello/intercom",
-  "version": "4.3.0",
+  "name": "@hildorjr/capacitor-intercom",
+  "version": "4.3.1",
   "description": "Enable Intercom features for Capacitor apps",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -82,9 +82,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fiksuruoka-fi/intercom"
+    "url": "git+https://github.com/fiksuruoka-fi/intercom.git"
   },
   "bugs": {
     "url": "https://github.com/fiksuruoka-fi/intercom/issues"
+  },
+  "homepage": "https://github.com/fiksuruoka-fi/intercom#readme",
+  "directories": {
+    "example": "example"
   }
 }


### PR DESCRIPTION
## Description

The `setUserHash` method was not working properly on iOS because of this typo. TypeScript on the Capacitor specification asks for a "hmac" but the code was checking for "hmsc" on iOS.

Fixes #21 ([issue](https://github.com/Fiksuruoka-fi/capacitor-intercom/issues/21))

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested this by connecting to Intercom and sending the HMAC, to perform a secure login.

**Test Configuration**:

- Device/OS: Iphone 13

## Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate):

Add any screenshots or screen recordings that help visualize the changes made in this pull request.
