### PR TITLE
fix(ios): hmac typo

### DIFF
--- a/ios/Plugin/IntercomPlugin.swift
+++ b/ios/Plugin/IntercomPlugin.swift
@@ -266,7 +266,7 @@ public class IntercomPlugin: CAPPlugin {
     }
     
     @objc func setUserHash(_ call: CAPPluginCall) {
-        guard let hmac = call.getString("hmsc") else {
+        guard let hmac = call.getString("hmac") else {
             call.reject("hmac is missing or empty. Read intercom docs and generate it.")
             return
         }


### PR DESCRIPTION
## Description

The `setUserHash` method was not working properly on iOS because of this typo. TypeScript on the Capacitor specification asks for a "hmac" but the code was checking for "hmsc" on iOS.

Fixes #21 ([issue](https://github.com/Fiksuruoka-fi/capacitor-intercom/issues/21))

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested this by connecting to Intercom and sending the HMAC, to perform a secure login.

**Test Configuration**:

- Device/OS: Iphone 13

## Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate):

Add any screenshots or screen recordings that help visualize the changes made in this pull request.
